### PR TITLE
feat: Change timeRemaining to onTimeRemaining

### DIFF
--- a/example/src/main/java/com/qompium/fibricheckexample/FirstFragment.java
+++ b/example/src/main/java/com/qompium/fibricheckexample/FirstFragment.java
@@ -78,8 +78,8 @@ public class FirstFragment extends Fragment {
                 Log.i(TAG, "Callback: onHeartBeat: " + value);
             }
 
-            @Override public void timeRemaining(int seconds) {
-                Log.i(TAG, "Callback: timeRemaining");
+            @Override public void onTimeRemaining(int seconds) {
+                Log.i(TAG, "Callback: onTimeRemaining");
 
             }
 

--- a/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/FibriChecker.java
+++ b/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/FibriChecker.java
@@ -449,7 +449,7 @@ public abstract class FibriChecker implements CameraListener {
 
     if (timeRemaining != previousTime) {
       previousTime = timeRemaining;
-      fibriListener.timeRemaining(timeRemaining);
+      fibriListener.onTimeRemaining(timeRemaining);
     }
 
     return tms;

--- a/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/listeners/FibriListener.java
+++ b/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/listeners/FibriListener.java
@@ -32,7 +32,7 @@ public class FibriListener implements IFibriListener {
 
   }
 
-  @Override public void timeRemaining (int seconds) {
+  @Override public void onTimeRemaining (int seconds) {
 
   }
 

--- a/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/listeners/IFibriListener.java
+++ b/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/listeners/IFibriListener.java
@@ -18,7 +18,7 @@ public interface IFibriListener {
 
   void onMeasurementFinished ();
 
-  void timeRemaining (int seconds);
+  void onTimeRemaining (int seconds);
 
   void onMeasurementProcessed (MeasurementData measurementData);
 


### PR DESCRIPTION
All other SDK implementation use `onTimeRemaining` callbacks. This is the only difference in naming between Android and other implementations. 

In this PR this is made consistent across different SDK's.