### PR TITLE
Chore/fix jitpack building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
               fibricheck-camera-sdk/build.gradle
         outputs:
           release_created: ${{ steps.release.outputs.release_created }}
-    publish-package:
+    publish-package-github:
         runs-on: ubuntu-latest
         needs: release-new-version
         if: ${{needs.release-new-version.outputs.release_created}}
@@ -48,4 +48,17 @@ jobs:
               env:
                 GH_USERNAME: ${{ github.actor }}
                 GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+    publish-package-jitpack:
+        runs-on: ubuntu-latest
+        needs: release-new-version
+        if: ${{needs.release-new-version.outputs.release_created}}
+        steps:
+          - name: Get the release version, removing the v from the tag
+            id: get_version
+            run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+          - name: Request release from JitPack to trigger build
+            run: |
+              JITPACK_URL="https://jitpack.io/com/github/fibricheck/android-camera-sdk/${{ steps.get_version.outputs.VERSION }}/"
+              # timeout in 30 seconds to avoid waiting for build
+              curl -s -m 30 ${JITPACK_URL} || true
    

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This SDK should be used in conjunction with the FibriCheck Cloud. It only implem
 
 ## How to include
 
-### Add the dependency
+### Add the dependency using the GitHub Package Registry
 
 The Android Camera SDK package is hosted on GPR (GitHub Package Registry). You need to authenticate using a GitHub username and personal access token to access the package in your project. For more information, see ("Creating a personal access token")[https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token] in the GitHub documentation.
 
@@ -32,6 +32,27 @@ The dependency can then be added:
 ```groovy
 dependencies {
     implementation 'com.qompium:fibricheck-camera-sdk:0.3.0'
+}
+```
+<!-- x-release-please-end -->
+
+### Add the dependency using JitPack
+[JitPack](https://jitpack.io) is a package repository for Git and allows to add dependencies without having to authenticate (as with the GitHub package registry):
+
+Include the following configuration in your `build.gradle` file:
+```groovy
+allprojects {
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
+}
+```
+
+Add the dependency in the following way:
+<!-- x-release-please-start-version -->
+```groovy
+dependencies {
+        implementation 'com.github.fibricheck:android-camera-sdk:0.3.0'
 }
 ```
 <!-- x-release-please-end -->

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
+    id 'maven-publish'
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.4.2' apply false
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,5 +13,4 @@ dependencyResolutionManagement {
     }
 }
 rootProject.name = "Fibricheck Example"
-include ':example'
 include ':fibricheck-camera-sdk'


### PR DESCRIPTION
[jitpack](https://www.jitpack.io) is an easy to use package repository for git. It makes it easy and straightforward to publish public repositories without having to authenticate against GitHub.