### PR TITLE
fix: add serialized annotations for Flutter implementations

### DIFF
--- a/fibricheck-camera-sdk/build.gradle
+++ b/fibricheck-camera-sdk/build.gradle
@@ -51,3 +51,7 @@ afterEvaluate{
     }
 }
 
+dependencies {
+    implementation 'com.google.code.gson:gson:+'
+}
+

--- a/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/measurement/MeasurementData.java
+++ b/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/measurement/MeasurementData.java
@@ -1,5 +1,7 @@
 package com.qompium.fibricheck_camera_sdk.measurement;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -10,30 +12,43 @@ import static com.qompium.fibricheck_camera_sdk.measurement.Quadrant.QUADRANT_RO
 
 public class MeasurementData implements Serializable {
 
+  @SerializedName("heartrate")
   public double heartrate;
 
+  @SerializedName("attempts")
   public int attempts;
 
+  @SerializedName("quadrants")
   public List<List<YuvList>> quadrants;
 
+  @SerializedName("technical_details")
   public HashMap<String, Object> technical_details;
 
+  @SerializedName("time")
   public List<Integer> time;
 
+  @SerializedName("acc")
   public MotionData acc;
 
+  @SerializedName("rotation")
   public MotionData rotation;
 
+  @SerializedName("grav")
   public MotionData grav;
 
+  @SerializedName("gyro")
   public MotionData gyro;
 
+  @SerializedName("skippedPulseDetection")
   public boolean skippedPulseDetection = false;
 
+  @SerializedName("skippedFingerDetection")
   public boolean skippedFingerDetection = false;
 
+  @SerializedName("skippedMovementDetection")
   public boolean skippedMovementDetection = false;
 
+  @SerializedName("measurement_timestamp")
   public Number measurementTimestamp;
 
   public MeasurementData () {
@@ -95,10 +110,13 @@ public class MeasurementData implements Serializable {
 
   public class MotionData implements Serializable {
 
+    @SerializedName("x")
     public List<Float> x;
 
+    @SerializedName("y")
     public List<Float> y;
 
+    @SerializedName("z")
     public List<Float> z;
 
     public MotionData () {

--- a/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/measurement/YuvList.java
+++ b/fibricheck-camera-sdk/src/main/java/com/qompium/fibricheck_camera_sdk/measurement/YuvList.java
@@ -1,16 +1,22 @@
 package com.qompium.fibricheck_camera_sdk.measurement;
 
 import android.util.Log;
+
+import com.google.gson.annotations.SerializedName;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 public class YuvList implements Serializable {
 
+  @SerializedName("y")
   public List<Double> y;
 
+  @SerializedName("u")
   public List<Double> u;
 
+  @SerializedName("v")
   public List<Double> v;
 
   public YuvList () {

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,4 +13,5 @@ dependencyResolutionManagement {
     }
 }
 rootProject.name = "Fibricheck Example"
+include ':example'
 include ':fibricheck-camera-sdk'


### PR DESCRIPTION
This PR adds the change that was added to the native code in the Flutter Camera SDK to explicitly provide `@SerializedName` names, to avoid that field names get obfuscated in Flutter release builds.