### PR TITLE
build(FCRN-2108): updated jitpack

### DIFF
--- a/camerasdk/build.gradle
+++ b/camerasdk/build.gradle
@@ -65,7 +65,7 @@ publishing {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:+'
+    implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'androidx.core:core-ktx:1.13.1'
 }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,6 @@
 jdk:
-  - openjdk11
+  - openjdk17
+
+# Only build the camera sdk when using jitpack, skip example apps
+install:
+  - ./gradlew :camerasdk:build :camerasdk:publishToMavenLocal -x lint -x lintVitalRelease


### PR DESCRIPTION
- fixed a warning about maven not being able to handle '+' versions
- fixed jitpack using the wrong jdk
- made it so that jitpack skips building the example apps