### PR TITLE
Fixes CI build error

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,7 +32,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
           args: --tag v${{ inputs.version }} --output CHANGELOG.md


### PR DESCRIPTION
Updates the `orhun/git-cliff-action` to version `v4` in the release preparation workflow, which resolves a previous build error.